### PR TITLE
Fix user signup process to handle existing

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -70,21 +70,28 @@ exports.signup_get = async (req, res) => {
 };
 
 exports.signup_post = async (req, res) => {
-    const user = new User({
-        first_name: req.body.first_name,
-        last_name: req.body.last_name,
-        username: req.body.username,
-        password: bcrypt.hashSync(req.body.password, 10),
-        wallet_amount: 10000,
-        type: 'buyer',
-        address: req.body.address,
-    });
-
     try {
-        const newUser = await user.save();
+        const existingUser = await User.findOne({
+            username: req.body.username,
+        });
+        if (existingUser) {
+            req.flash('error', 'Username already exists');
+            return res.redirect('/users/signup');
+        }
+        const user = new User({
+            first_name: req.body.first_name,
+            last_name: req.body.last_name,
+            username: req.body.username,
+            password: bcrypt.hashSync(req.body.password, 10),
+            wallet_amount: 0,
+            type: req.body.type,
+            address: req.body.address,
+        });
+        await user.save();
         res.redirect('/users/login');
     } catch (err) {
-        res.status(500).json(err);
+        req.flash('error', 'An error occurred');
+        res.redirect('/users/signup');
     }
 };
 

--- a/views/signup_form.ejs
+++ b/views/signup_form.ejs
@@ -32,6 +32,16 @@
     <div>Book<span>Era</span></div>
 </div>
 <div class="login">
+    <% if (success.length > 0) { %>
+        <div class="alert alert-success">
+            <%= success %>
+        </div>
+    <% } %>
+    <% if (error.length > 0) { %>
+        <div class="alert alert-danger">
+            <%= error %>
+        </div>
+    <% } %>
     <form action="/users/signup" method="POST">
         <input type="text" id="first_name" name="first_name" placeholder="First Name" required>
         <input type="text" id="last_name" name="last_name" placeholder="Last Name" required>


### PR DESCRIPTION
This PR includes changes to the user signup process to handle cases where the username already exists. Now, when a user tries to sign up with a username that's already in use, they'll see an error message and be redirected back to the signup form.